### PR TITLE
Make eldoc documentation work when point is in a function argument list.

### DIFF
--- a/php-extras.el
+++ b/php-extras.el
@@ -94,7 +94,12 @@ variable. If prefix argument is negative search forward."
   (when (eq php-extras-function-arguments 'not-loaded)
     (require 'php-extras-eldoc-functions php-extras-eldoc-functions-file t))
   (when (hash-table-p php-extras-function-arguments)
-    (gethash (php-get-pattern) php-extras-function-arguments)))
+    (or                                 
+     (gethash (php-get-pattern) php-extras-function-arguments)
+     (save-excursion
+       (ignore-errors
+         (backward-up-list)
+         (gethash (php-get-pattern) php-extras-function-arguments))))))
 
 ;;;###autoload
 (add-hook 'php-mode-hook #'(lambda ()


### PR DESCRIPTION
Hi!
Thanks for php-extras. I've been using it for work coding after being away from PHP for a while and it's making things much more pleasant.

This patch is a simple hack which improves the Eldoc support (IMO) by continuing to show the argument hints when point is within a function argument list.  It works very simply: if the first call to `(gethash ...)' returns nil, then Emacs tries to go up one level of parens (when possible) and look up whatever symbol it finds there instead.

It might not be too hard to get it to highlight the current argument as well, but I've been too lazy to work that out so far ;-)
