### PR TITLE
Allow `completion-at-point' to use php-extras' cached function names.

### DIFF
--- a/php-extras.el
+++ b/php-extras.el
@@ -100,7 +100,10 @@ variable. If prefix argument is negative search forward."
 (add-hook 'php-mode-hook #'(lambda ()
                              (unless eldoc-documentation-function
                                (set (make-local-variable 'eldoc-documentation-function)
-                                    #'php-extras-eldoc-documentation-function))))
+                                    #'php-extras-eldoc-documentation-function))
+                             (add-hook 'completion-at-point-functions
+                                       #'php-extras-completion-at-point
+                                       nil t)))
 
 
 
@@ -153,6 +156,21 @@ The candidates are generated from the
 
 ;;;###autoload
 (add-hook 'php-mode-hook #'php-extras-autocomplete-setup)
+
+
+;;; Setup basic Emacs completion-at-point to complete on function names
+
+;;;###autoload
+(defun php-extras-completion-at-point ()
+  (when (eq php-extras-function-arguments 'not-loaded)
+    (require 'php-extras-eldoc-functions php-extras-eldoc-functions-file t))
+  (when (hash-table-p php-extras-function-arguments)
+    (let ((bounds (bounds-of-thing-at-point 'symbol))
+          (symbol (symbol-name (symbol-at-point))))
+      (if (try-completion symbol php-extras-function-arguments)
+          (list (car bounds) (cdr bounds) php-extras-function-arguments)
+        nil))))
+
 
 
 


### PR DESCRIPTION
This is another very simple patch which lets php-extras provide completions for Emacs' built-in completion mechanism (`completion-at-point`) as well as for auto-complete. I know, everyone else uses auto-complete, but sometimes I prefer the plain old pop-up buffer style ;-)

This patch defines one new function, `php-extras-completion-at-point`, and adds it locally to the `completion-at-point-functions` hook in the php-mode hook. This allows completing PHP function names using Emacs' built-in completion system.

`php-mode` claims to have something similar to this, but I can't get it to work, and I like the fact that `php-extras` can index the current version of the manual from the net.

Note: I think that, if this patch is accepted, the code for lazy-loading the file with the hash table of functions will be duplicated in three places. It might be worth factoring that out into a separate function (and maybe provide a helpful message if the file isn't found for some reason). I'm happy to submit an extra patch to do that if you like.
