### PR TITLE
Simplify completion at point

### DIFF
--- a/php-extras.el
+++ b/php-extras.el
@@ -177,6 +177,14 @@ The candidates are generated from the
                 :exclusive 'no)
         nil))))
 
+;;;###autoload
+(defun php-extras-completion-setup ()
+  (add-hook 'completion-at-point-functions
+            #'php-extras-completion-at-point
+            nil t))
+
+;;;###autoload
+(add-hook 'php-mode-hook #'php-extras-completion-setup)
 
 
 


### PR DESCRIPTION
This branch contains a few simple improvements to the original completion-at-point patch:
- avoid doing a redundant call to `try-completion` by returning `:exclusive 'no` as properties
- add `(require 'thingatpt)` (I think it is auto-loaded anyway, but just to be safe)
- split the setup of `completion-at-point-functions` into its own defun and add it to `php-mode-hook`
