### PR TITLE
Fix function argument annotations in company-mode

### DIFF
--- a/php-extras.el
+++ b/php-extras.el
@@ -239,9 +239,9 @@ The candidates are generated from the
        (all-completions candidate php-extras-function-arguments))
 
       (annotation
-       (let ((arguments (php-extras-get-function-property candidate 'prototype)))
-         (and arguments
-              (replace-regexp-in-string "\\`[^(]*" "" arguments))))
+       (let ((prototype (php-extras-get-function-property candidate 'prototype)))
+         (and prototype
+              (replace-regexp-in-string "\\`[^(]*" "" prototype))))
 
       (meta
        (php-extras-get-function-property candidate 'purpose))


### PR DESCRIPTION
This fixes a dumb mistake in my original patch to add company-mode support. The original patch put the whole string including return type and function name inside the parentheses.  I knew that the function argument strings seemed awfully long but I couldn't figure out why .. duh.

This one strips off everything before the first open-paren when using the string as a company-mode annotation.
